### PR TITLE
streamline slash command CLI

### DIFF
--- a/example-slackapp/app_errors.py
+++ b/example-slackapp/app_errors.py
@@ -1,3 +1,8 @@
+import sys
+import json
+import traceback
+
+
 from werkzeug.exceptions import Unauthorized
 from flask import jsonify
 from app_data import slackapp
@@ -37,7 +42,9 @@ def on_slack_apierror(exc):
 
 
 def on_general_exception(exc):
-    errmsg = f"Unexpected error: {str(exc)}"
+    exc_info = sys.exc_info()
+    tb_content = json.dumps(traceback.format_tb(exc_info[2]), indent=3)
+    errmsg = f"Unexpected error: {str(exc)}:\n{tb_content}"
     msg = dict(blocks=[SectionBlock(text=errmsg).to_dict()])
     return jsonify(msg)
 

--- a/example-slackapp/commands/demo/__init__.py
+++ b/example-slackapp/commands/demo/__init__.py
@@ -1,4 +1,4 @@
-from . import cli
+from . import main
 from . import apptest_block
 from . import apptest_dialog
 from . import apptest_modal

--- a/example-slackapp/commands/demo/cli.py
+++ b/example-slackapp/commands/demo/cli.py
@@ -3,8 +3,6 @@ from slackapptk.cli import SlackAppTKParser
 
 from app_data import slackapp
 
-from . import main
-
 demo_parser = SlackAppTKParser(
     prog='demo',
     description="This command showcases the use of argsparse for rich CLI constructs"
@@ -20,10 +18,7 @@ demo_cmds = demo_parser.add_subparsers(
     title='demo commands'
 )
 
-slash_demo = slackapp.commands.register(
-    parser=demo_parser,
-    callback=main.main_demo
-)
+slash_demo = slackapp.commands.register(demo_parser)
 
 # Note: each of the demo subcommands will define additiona CLI parsers bound to
 # the demo_cmds instance.  See each file for details.

--- a/example-slackapp/commands/demo/main.py
+++ b/example-slackapp/commands/demo/main.py
@@ -32,9 +32,14 @@ from slack.web.classes import (
 # SlackAppTK Imports
 # -----------------------------------------------------------------------------
 
-from slackapptk.cli import SlashCommandCLI
 from slackapptk.request.command import CommandRequest
 from slackapptk.response import Response
+
+# -----------------------------------------------------------------------------
+# Private Imports
+# -----------------------------------------------------------------------------
+
+from .cli import demo_parser, slash_demo
 
 # -----------------------------------------------------------------------------
 #
@@ -46,16 +51,15 @@ from slackapptk.response import Response
 COLOR_GREEN = '#008000'
 
 
-def main_demo(
-    slash_demo: SlashCommandCLI,
-    rqst: CommandRequest
-):
+@slash_demo.cli.on(demo_parser.prog)
+def main_demo(rqst: CommandRequest):
+
     # The callback_id will be based on the parser prog name, which is "demo" in
     # this case; but showing the use programatically.  This value will be used
     # to bind to the Slack message options and the callback which will be used
     # to run the command associated with the User's selection.
 
-    callback_id = slash_demo.parser.prog
+    callback_id = demo_parser.prog
 
     # create a Slack message that will be used to respond to the User's
     # interaction which was the invocation of the /demo command.
@@ -72,7 +76,7 @@ def main_demo(
     # the CLI sub parser items; which are made available through a `choices`
     # property of the SlackAppTKParser instance.
 
-    demo_choices = slash_demo.parser.choices
+    demo_choices = demo_parser.choices
 
     # Using those command choices, create a list of Option widgets whose label
     # comes from the CLI command help string and the value is the CLI program

--- a/example-slackapp/commands/ping/cli.py
+++ b/example-slackapp/commands/ping/cli.py
@@ -2,7 +2,6 @@ from slackapptk.cli import SlackAppTKParser
 
 from app_data import slackapp
 
-from . import main
 
 ping_parser = SlackAppTKParser(
     prog='ping',
@@ -15,7 +14,4 @@ ping_parser.add_argument(
     choices=['public', 'private']
 )
 
-slash_ping = slackapp.commands.register(
-    parser=ping_parser,
-    callback=main.ping
-)
+slash_ping = slackapp.commands.register(ping_parser)

--- a/example-slackapp/commands/ping/main.py
+++ b/example-slackapp/commands/ping/main.py
@@ -1,14 +1,20 @@
 
-from slackapptk.cli import SlashCommandCLI
+# -----------------------------------------------------------------------------
+# SlackAppTK Imports
+# -----------------------------------------------------------------------------
+
 from slackapptk.request.command import CommandRequest
 from slackapptk.response import Response
 
+# -----------------------------------------------------------------------------
+# Private Imports
+# -----------------------------------------------------------------------------
 
-# noinspection PyUnusedLocal
-def ping(
-    slashcli: SlashCommandCLI,
-    rqst: CommandRequest
-) -> None:
+from .cli import slash_ping, ping_parser
+
+
+@slash_ping.cli.on(ping_parser.prog)
+def ping(rqst: CommandRequest) -> None:
     """
     Called with no params, default is to ping privately.
     """

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup, find_packages
 
-package_version = '0.7.0'
+package_version = '0.8.0'
 package_name = 'slackapptk'
 
 

--- a/slackapptk/app.py
+++ b/slackapptk/app.py
@@ -75,11 +75,8 @@ class SlackAppCommands(object):
         self.app = app
         self._registry = dict()
 
-    def register(self, parser, callback):
-        cmd = self._registry[parser.prog] = SlashCommandCLI(
-            parser=parser,
-            callback=callback
-        )
+    def register(self, parser):
+        cmd = self._registry[parser.prog] = SlashCommandCLI(parser=parser)
         return cmd
 
     def run(
@@ -114,22 +111,24 @@ class SlackAppCommands(object):
             self.app.log.error(emsg)
             raise SlackAppTKError(emsg, name, rqst)
 
+        return slashcli.run(rqst)
+
         # if the User provided command line parameters then "run" their
         # command; code execution will pickup via a bound callback handler
         # depending on what the User entered; which is slash-commmand specific.
 
-        if len(rqst.argv):
-            return slashcli.run(rqst)
-
-        # Otherwise, the User did not provide any additional CLI options,
-        # continue code execution at the SlashCLI callback handler
-
-        if not slashcli.callback:
-            emsg = f'Missing slash command callback for {name}'
-            self.app.log.error(emsg)
-            raise SlackAppTKError(emsg, name, rqst)
-
-        return slashcli.callback(slashcli, rqst)
+        # if len(rqst.argv):
+        #     return slashcli.run(rqst)
+        #
+        # # Otherwise, the User did not provide any additional CLI options,
+        # # continue code execution at the SlashCLI callback handler
+        #
+        # if not slashcli.callback:
+        #     emsg = f'Missing slash command callback for {name}'
+        #     self.app.log.error(emsg)
+        #     raise SlackAppTKError(emsg, name, rqst)
+        #
+        # return slashcli.callback(slashcli, rqst)
 
 
 class SlackApp(object):

--- a/slackapptk/app.py
+++ b/slackapptk/app.py
@@ -113,23 +113,6 @@ class SlackAppCommands(object):
 
         return slashcli.run(rqst)
 
-        # if the User provided command line parameters then "run" their
-        # command; code execution will pickup via a bound callback handler
-        # depending on what the User entered; which is slash-commmand specific.
-
-        # if len(rqst.argv):
-        #     return slashcli.run(rqst)
-        #
-        # # Otherwise, the User did not provide any additional CLI options,
-        # # continue code execution at the SlashCLI callback handler
-        #
-        # if not slashcli.callback:
-        #     emsg = f'Missing slash command callback for {name}'
-        #     self.app.log.error(emsg)
-        #     raise SlackAppTKError(emsg, name, rqst)
-        #
-        # return slashcli.callback(slashcli, rqst)
-
 
 class SlackApp(object):
 

--- a/slackapptk/cli.py
+++ b/slackapptk/cli.py
@@ -7,7 +7,7 @@ parsing utilizing the Python standard argparse module.
 # System Imports
 # -----------------------------------------------------------------------------
 
-from typing import Optional, Callable, Dict, Text, NoReturn
+from typing import Optional, Dict, Text, NoReturn
 
 from inspect import stack, signature
 from argparse import ArgumentParser, SUPPRESS, Namespace
@@ -213,12 +213,11 @@ class SlackAppTKParser(ArgumentParser):
 
 class SlashCommandCLI(object):
 
-    def __init__(self, parser: SlackAppTKParser, callback: Callable):
+    def __init__(self, parser: SlackAppTKParser):
         self.name = parser.prog
         self.parser = parser
         self.ic = pyee.EventEmitter()
         self.cli = pyee.EventEmitter()
-        self.callback = callback
 
     def run(self, rqst, event=None):
 

--- a/slackapptk/messenger.py
+++ b/slackapptk/messenger.py
@@ -14,8 +14,6 @@
 
 from typing import Optional, Any
 import asyncio
-import aiohttp
-from aiohttp import ClientResponse
 
 from collections import UserDict
 from slack.web.client import WebClient
@@ -74,7 +72,34 @@ class Messenger(UserDict):
         response_url: Optional[str] = None,
         **kwargs: Optional[Any]
     ):
+        """
+        This method is used to send a message via the response_url rathern
+        than using the api.slack.com endpoints.
 
+        Parameters
+        ----------
+        response_url: str
+            The message will be POST to this URL; originates from a message received
+            from api.slack.com
+
+        Other Parameters
+        ----------------
+        Any other kwargs are passed as content into the message.
+
+        Raises
+        ------
+        SlackApiError upon error sending; HTTP status code other
+        than 200.
+
+        Returns
+        -------
+        True if the message was sent without error (HTTP code 200).
+
+        Notes
+        -----
+        Ideally this method should be a part of the `slackclient` BaseClient class to avoid
+        using the internals of the client instance.  TODO: open issue with that repo.
+        """
         req_args = dict(
             # contents of messenger[UserDict]
             **self,


### PR DESCRIPTION
Changed the API for registering SlackAppTKParser into the app so that the `callback` argument is no longer required.  That said, you will now need to bind your callback using the same mechanism for all other callback handlers.  For example, see the files in the example app:

- demo/cli.py
- demo/main.py


